### PR TITLE
Add unmount event

### DIFF
--- a/src/Nova.jsx
+++ b/src/Nova.jsx
@@ -29,6 +29,17 @@ class Nova extends Component {
     }
   }
 
+  componentWillUnmount() {
+    if (window !== "undefined") {
+      const id = this.placeholder.current.getAttribute("data-hypernova-id");
+      const { name } = this.props;
+      const customEvent = new CustomEvent('NovaUnmount', {
+        detail: { id, name },
+      });
+      document.dispatchEvent(customEvent);
+    }
+  }
+
   render() {
     const { name, data } = this.props;
     return (

--- a/src/Nova.jsx
+++ b/src/Nova.jsx
@@ -30,7 +30,7 @@ class Nova extends Component {
   }
 
   componentWillUnmount() {
-    if (window !== "undefined") {
+    if (window !== 'undefined') {
       const id = this.placeholder.current.getAttribute("data-hypernova-id");
       const { name } = this.props;
       const customEvent = new CustomEvent('NovaUnmount', {


### PR DESCRIPTION
When Nova bridge is unmounted, even though the dom is removed, the virtual tree created by Nova using `ReactDOM.render()` does not get removed.
`render` method create a new tree will not be reconciled properly and need to be cleaned up manually.

This event will help the users to handle the unmount and do the cleanup manually when Nova unmounts.